### PR TITLE
Update README badges to use `main` instead of `setup` branch

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,10 +8,10 @@
     platform.
   </p>
 
-[![Angular Version](https://img.shields.io/badge/dynamic/json?url=https%3A%2F%2Fraw.githubusercontent.com%2Fwisdom-oss%2Ffrontend%2Frefs%2Fheads%2Fsetup%2Fpackage-lock.json&query=packages.node_modules%2F%40angular%2Fcore.version&prefix=v&style=for-the-badge&logo=angular&label=angular&color=%23B52E31)](https://angular.dev)
-[![Node Version](https://img.shields.io/badge/dynamic/json?url=https%3A%2F%2Fraw.githubusercontent.com%2Fwisdom-oss%2Ffrontend%2Frefs%2Fheads%2Fsetup%2Fpackage.json&query=volta.node&prefix=v&style=for-the-badge&logo=node&label=node&color=%23339933)](https://nodejs.org)
-[![Bulma Version](https://img.shields.io/badge/dynamic/json?url=https%3A%2F%2Fraw.githubusercontent.com%2Fwisdom-oss%2Ffrontend%2Frefs%2Fheads%2Fsetup%2Fpackage-lock.json&query=packages.node_modules%2Fbulma.version&prefix=v&style=for-the-badge&logo=bulma&label=bulma&color=%2300D1B2)](https://bulma.io)
-[![License](https://img.shields.io/badge/dynamic/json?url=https%3A%2F%2Fraw.githubusercontent.com%2Fwisdom-oss%2Ffrontend%2Frefs%2Fheads%2Fsetup%2Fpackage.json&query=license&style=for-the-badge&label=license&color=%23003399)](./LICENSE)
+[![Angular Version](https://img.shields.io/badge/dynamic/json?url=https%3A%2F%2Fraw.githubusercontent.com%2Fwisdom-oss%2Ffrontend%2Frefs%2Fheads%2Fmain%2Fpackage-lock.json&query=packages.node_modules%2F%40angular%2Fcore.version&prefix=v&style=for-the-badge&logo=angular&label=angular&color=%23B52E31)](https://angular.dev)
+[![Node Version](https://img.shields.io/badge/dynamic/json?url=https%3A%2F%2Fraw.githubusercontent.com%2Fwisdom-oss%2Ffrontend%2Frefs%2Fheads%2Fmain%2Fpackage.json&query=volta.node&prefix=v&style=for-the-badge&logo=node&label=node&color=%23339933)](https://nodejs.org)
+[![Bulma Version](https://img.shields.io/badge/dynamic/json?url=https%3A%2F%2Fraw.githubusercontent.com%2Fwisdom-oss%2Ffrontend%2Frefs%2Fheads%2Fmain%2Fpackage-lock.json&query=packages.node_modules%2Fbulma.version&prefix=v&style=for-the-badge&logo=bulma&label=bulma&color=%2300D1B2)](https://bulma.io)
+[![License](https://img.shields.io/badge/dynamic/json?url=https%3A%2F%2Fraw.githubusercontent.com%2Fwisdom-oss%2Ffrontend%2Frefs%2Fheads%2Fmain%2Fpackage.json&query=license&style=for-the-badge&label=license&color=%23003399)](./LICENSE)
 
 </div>
 


### PR DESCRIPTION
The URLs in the README badges previously used dynamic shields to fetch data from the `setup` branch. Now that #1 has been merged, we can update the links to point to the `main` branch.