### PR TITLE
Remember sidebar toggle

### DIFF
--- a/src/core/core.component.ts
+++ b/src/core/core.component.ts
@@ -1,11 +1,12 @@
 import {NgIf} from "@angular/common";
-import {Component} from "@angular/core";
+import {effect, Component} from "@angular/core";
 import {RouterOutlet} from "@angular/router";
 
 import {NavbarComponent} from "./navbar/navbar.component";
 import {SidebarComponent} from "./sidebar/sidebar.component";
 import {signals} from "../common/signals";
 import {IsAutoHideDirective} from "../common/directives/is-auto-hide.directive";
+import {StorageService} from "../common/storage.service";
 
 @Component({
   selector: "core",
@@ -18,8 +19,22 @@ import {IsAutoHideDirective} from "../common/directives/is-auto-hide.directive";
 })
 export class CoreComponent {
   sidebarActive = signals.toggleable(true);
+  storage: StorageService.Storages;
 
-  constructor(private autoHideService: IsAutoHideDirective.Service) {}
+  constructor(
+    private autoHideService: IsAutoHideDirective.Service,
+    storageService: StorageService,
+  ) {
+    this.storage = storageService.instance(CoreComponent);
+
+    effect(() =>
+      this.storage.session.set("sidebar", JSON.stringify(this.sidebarActive())),
+    );
+    
+    this.sidebarActive.set(
+      JSON.parse(this.storage.session.get("sidebar") ?? "true"),
+    );
+  }
 
   onClick(event: PointerEvent) {
     if (!(event.target instanceof Element)) return;


### PR DESCRIPTION
This PR adds a value to the session storage that remembers the state of the sidebar toggle. This allows reloading and keeping the sidebar closed.