### PR TITLE
Fix Docker build by using Volta via install script

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -29,7 +29,7 @@ RUN volta run npm run build
 
 
 # host the app via the static file server
-FROM sigoden/dufs
+FROM sigoden/dufs:v${DUFS_VERSION}
 WORKDIR /wisdom-oss
 COPY --from=build-app /app/dist/wisdom-oss/frontend/browser /wisdom-oss/app
 EXPOSE 5000

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,17 +1,19 @@
-ARG VOLTA_TAG=v2.0.1
+ARG VOLTA_VERSION=2.0.1
 ARG DUFS_VERSION=0.43.0
-ARG RUST_VERSION=1.84.1
 
 
 # build the app via volta to use the correct node version
-FROM rust:${RUST_VERSION}-bookworm AS build-app
+FROM debian:bookworm AS build-app
 RUN apt update -y && apt upgrade -y
+RUN apt install -y curl
 WORKDIR /app
 
-# install volta directly from source
-ARG VOLTA_TAG
-RUN cargo install --git https://github.com/volta-cli/volta.git --tag $VOLTA_TAG --locked
-ENV PATH="bin/volta/bin:$PATH"
+# install volta to install correct node version
+RUN curl -o install-volta.sh -L --proto "=https" --tlsv1.2 -sSf https://get.volta.sh
+ARG VOLTA_VERSION
+ENV VOLTA_HOME="/.volta"
+RUN bash install-volta.sh --version ${VOLTA_VERSION}
+ENV PATH="$VOLTA_HOME/bin:$PATH"
 
 # install node
 COPY --link package.json .
@@ -24,6 +26,7 @@ RUN volta run npm ci
 # build the app
 COPY --link . .
 RUN volta run npm run build
+
 
 # host the app via the static file server
 FROM sigoden/dufs

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,9 +1,10 @@
 ARG VOLTA_TAG=v2.0.1
 ARG DUFS_VERSION=0.43.0
+ARG RUST_VERSION=1.84.1
 
 
 # build the app via volta to use the correct node version
-FROM rust:latest AS build-app
+FROM rust:${RUST_VERSION}-bookworm AS build-app
 RUN apt update -y && apt upgrade -y
 WORKDIR /app
 


### PR DESCRIPTION
The Docker image used to build Volta directly from source to ensure the correct version. But that takes a lot of time and seems to fail sometimes. To avoid this, we use the install script from their website now. It now provides an argument to install a specific version of Volta which allows pinning it, as we wanted to. With this we should have faster and more stable builds.