### PR TITLE
Added pre-hooks via husky to project

### DIFF
--- a/.husky/pre-commit
+++ b/.husky/pre-commit
@@ -1,0 +1,4 @@
+npm run fmt
+npm run lint
+git add .
+

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -70,16 +70,19 @@ The [CI](https://github.com/wisdom-oss/frontend/actions) enforces this.
 
 ## Git Pre-Commit Hooks
 
-In order to automatically format and lint the codebase, you can use husky (https://typicode.github.io/husky/get-started.html)
+In order to automatically format and lint the codebase,
+you can use husky (https://typicode.github.io/husky/get-started.html)
 install via
-'''sh
-npm install --save-dev husky
-'''
+
+```sh
+npm install --global husky
+```
 
 and make sure npm still functions with repeating
-'''sh
+
+```sh
 npm install
-'''
+```
 
 Then, whenever you commit anything via git or GitHub Desktop, both scripts get executed
 before the commit happens and you don't have to do so manually

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -68,6 +68,22 @@ Key scripts include:
 Ensure you run `lint` and `fmt` before pushing.
 The [CI](https://github.com/wisdom-oss/frontend/actions) enforces this.
 
+## Git Pre-Commit Hooks
+
+In order to automatically format and lint the codebase, you can use husky (https://typicode.github.io/husky/get-started.html)
+install via
+'''sh
+npm install --save-dev husky
+'''
+
+and make sure npm still functions with repeating
+'''sh
+npm install
+'''
+
+Then, whenever you commit anything via git or GitHub Desktop, both scripts get executed
+before the commit happens and you don't have to do so manually
+
 ## Code Organization
 
 ### File and Directories
@@ -156,7 +172,7 @@ Most **MIT** and **Apache**-licensed packages are fine.
 
 Before submitting a PR:
 
-- Run `npm run lint` and `npm run fmt` to pass CI checks.
+- Run `npm run lint` and `npm run fmt` to pass CI checks. (see ## Git Pre-Commit Hooks above)
 - Ensure your module aligns with the project's structure and standards.
 - Familiarize yourself with `src/common` — it might already contain what you need.
 

--- a/package.json
+++ b/package.json
@@ -16,7 +16,8 @@
     "compodoc:serve": "compodoc -s",
     "docker:build": "docker build -t wisdom-oss/frontend .",
     "docker:start": "npm run docker:run",
-    "docker:run": "docker run --rm -p 5000:5000 wisdom-oss/frontend"
+    "docker:run": "docker run --rm -p 5000:5000 wisdom-oss/frontend",
+    "git-hooks": "husky"
   },
   "private": true,
   "dependencies": {


### PR DESCRIPTION
https://typicode.github.io/husky/get-started.html

used to do the formatting and linting required by the CICD before every commit.
Available via GitHub Desktop aswell.

CAUTION: Not in Dependency, so gets ignored when not setup in your personal setup.