### PR TITLE
Let Prettier ignore generated files

### DIFF
--- a/.prettierignore
+++ b/.prettierignore
@@ -1,0 +1,3 @@
+# Generated Output
+src/assets/generated/
+public/generated/

--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -11,6 +11,9 @@
     "**/.project": true,
     "**/.settings": true
   },
+  "files.associations": {
+    "*.prettierignore": "ignore"
+  },
   "cSpell.language": "en,de-DE",
   "typescript.tsdk": "./node_modules/typescript/lib"
 }


### PR DESCRIPTION
We generate at build-time a lot of files and some of these were formatted by prettier which is kinda useless. By adding this `.prettierignore` we can tell prettier to not format these files. This reduces the formatting time drastically.