### PR TITLE
Fix weird startup error

### DIFF
--- a/src/index.html
+++ b/src/index.html
@@ -8,7 +8,7 @@
     <link rel="icon" type="image/x-icon" href="public/favicon.ico" />
     <meta name="theme-color" content="#0088aa" />
   </head>
-  <body>
-    <app></app>
-  </body>
+  <!-- prettier-ignore -->
+  <body><app></app></body>
+  <!-- this avoids a weird error at startup -->
 </html>


### PR DESCRIPTION
For some reason handles Angular at startup elements in the `body` very strictly causing this error:
![image](https://github.com/user-attachments/assets/d9ee7b65-52ea-4dd5-997e-bd37a475a4a2)

By moving everything into one line `<body><app></app></body>`, this error disappears.

![](https://media2.giphy.com/media/v1.Y2lkPTc5MGI3NjExMWQ2ZGc5N2k2d2V6ZTNrMHg4dHhodmhlaWp0amR6OGt3Y3FhcWFycCZlcD12MV9pbnRlcm5hbF9naWZfYnlfaWQmY3Q9Zw/ZeNmLY6FISq4M/giphy.gif)