### PR TITLE
Add `signals.fromPromise`

### DIFF
--- a/src/common/signals.spec.ts
+++ b/src/common/signals.spec.ts
@@ -1,0 +1,29 @@
+import {signals} from "./signals";
+
+describe("signals.fromPromise", () => {
+  it("should work without mapping function", async () => {
+    let resolve!: (value: boolean) => void;
+    let promise = new Promise<boolean>(res => (resolve = res));
+    let signal = signals.fromPromise(promise);
+
+    expect(signal()).toBeUndefined();
+
+    resolve(true);
+    await promise;
+
+    expect(signal()).toBe(true);
+  });
+
+  it("should work with a mapping function", async () => {
+    let resolve!: (value: {name: string}) => void;
+    let promise = new Promise<{name: string}>(res => (resolve = res));
+    let signal = signals.fromPromise(promise, ({name}) => name);
+
+    expect(signal()).toBeUndefined();
+
+    resolve({name: "Squidward"});
+    await promise;
+
+    expect(signal()).toBe("Squidward");
+  });
+});

--- a/src/common/signals.ts
+++ b/src/common/signals.ts
@@ -126,9 +126,9 @@ export namespace signals {
    * Initially, the signal holds `undefined`.
    * When the promise resolves, the signal updates with the mapped value.
    *
-   * This can very useful when working with API services which often return 
+   * This can very useful when working with API services which often return
    * promises.
-   * 
+   *
    * @param map A mapping function to transform the resolved value before
    *            storing it in the signal.
    *            Defaults to an identity function.

--- a/src/common/signals.ts
+++ b/src/common/signals.ts
@@ -117,4 +117,39 @@ export namespace signals {
     });
     return delayed;
   }
+
+  /**
+   * Creates a signal from a promise.
+   *
+   * This function takes a promise and returns a signal that updates with the
+   * resolved value of the promise.
+   * Initially, the signal holds `undefined`.
+   * When the promise resolves, the signal updates with the mapped value.
+   *
+   * This can very useful when working with API services which often return 
+   * promises.
+   * 
+   * @param map A mapping function to transform the resolved value before
+   *            storing it in the signal.
+   *            Defaults to an identity function.
+   *
+   * @example
+   * const mySignal = signals.fromPromise(fetchData());
+   *
+   * effect(() => {
+   *   console.log(mySignal()); // Initially undefined, then updates with resolved value.
+   * });
+   *
+   * @example
+   * // Using a mapping function
+   * const userSignal = signals.fromPromise(fetchUser(), user => user.name);
+   */
+  export function fromPromise<T, U = T>(
+    promise: Promise<T>,
+    map: (value: T) => U = value => value as unknown as U,
+  ): Signal<undefined | U> {
+    let mapped = signal<undefined | U>(undefined);
+    promise.then(value => mapped.set(map(value)));
+    return mapped;
+  }
 }


### PR DESCRIPTION
While working with API services you often encounter promises but in the components it is usually more simple working with signals. This new `signals.fromPromise` factory helps with that.