### PR TITLE
Remove obsolete entry point component

### DIFF
--- a/src/modules/long-term-forecast/long-term-forecast.component.ts
+++ b/src/modules/long-term-forecast/long-term-forecast.component.ts
@@ -1,9 +1,0 @@
-import {Component} from "@angular/core";
-import {RouterOutlet} from "@angular/router";
-
-@Component({
-  imports: [RouterOutlet],
-  template: "<router-outlet></router-outlet>",
-  styles: ``,
-})
-export class LongTermForecastComponent {}

--- a/src/routes.ts
+++ b/src/routes.ts
@@ -6,7 +6,6 @@ import {permissionsGuard} from "./core/auth/permissions.guard";
 import {GreeterComponent} from "./core/greeter/greeter.component";
 import {BeWaterSmartComponent} from "./modules/be-water-smart/be-water-smart.component";
 import {GrowlComponent} from "./modules/growl/growl.component";
-import {LongTermForecastComponent} from "./modules/long-term-forecast/long-term-forecast.component";
 import {longTermForecastRoutes} from "./modules/long-term-forecast/routes";
 import {OowvActionMapComponent} from "./modules/oowv/action-map/action-map.component";
 import {PumpModelsComponent} from "./modules/pump-models/pump-models.component";
@@ -24,7 +23,6 @@ export const routes: Routes = [
       {path: "growl", component: GrowlComponent},
       {
         path: "long-term-forecast",
-        component: LongTermForecastComponent,
         children: longTermForecastRoutes,
       },
       {


### PR DESCRIPTION
Components that just do this:

```ts
import {Component} from "@angular/core";
import {RouterOutlet} from "@angular/router";

@Component({
  imports: [RouterOutlet],
  template: "<router-outlet></router-outlet>",
  styles: ``,
})
export class LongTermForecastComponent {}
```

Can be left out.