### PR TITLE
chore: changing water rights service API path

### DIFF
--- a/src/api/water-rights.service.ts
+++ b/src/api/water-rights.service.ts
@@ -17,7 +17,7 @@ import {httpContexts} from "../common/http-contexts";
 import {Once} from "../common/utils/once";
 import {typeUtils} from "../common/utils/type-utils";
 
-const URL = "/api/water-rights" as const;
+const URL = "/api/water-rights/v1" as const;
 
 @Injectable({
   providedIn: "root",


### PR DESCRIPTION
this pr adds `v1` to the water rights service call to ensure compatibility with the upgraded API endpoints